### PR TITLE
Modify get_ast.py to return only name

### DIFF
--- a/data_utils/get_ast.py
+++ b/data_utils/get_ast.py
@@ -82,7 +82,7 @@ def get_ast(file_name, w):
                         for j in range(i + 1, len(flatten)):
                             if child_path == flatten[j]['path']:
                                 children.append(j)
-                d["id"] = get_name(i)
+                d["id"] = i
                 d["type"] = get_name(node)
                 if children:
                     d["children"] = children

--- a/data_utils/get_ast.py
+++ b/data_utils/get_ast.py
@@ -5,6 +5,23 @@ import collections
 import sys
 
 
+def get_name(obj):
+    if(type(obj).__name__ in ['list', 'tuple']):
+        a = []
+        for i in obj:
+            a.append(get_name(i))
+        return a
+    elif(type(obj).__name__ in ['dict', 'OrderedDict']):
+        a = {}
+        for k in obj:
+            a[k] = get_name(obj[k])
+        return a
+    elif(type(obj).__name__ not in ['int', 'float', 'str', 'bool']):
+        return type(obj).__name__
+    else:
+        return obj
+
+
 def process_source(file_name, save_file):
     with open(file_name, 'r', encoding='utf-8') as source:
         lines = source.readlines()
@@ -65,8 +82,8 @@ def get_ast(file_name, w):
                         for j in range(i + 1, len(flatten)):
                             if child_path == flatten[j]['path']:
                                 children.append(j)
-                d["id"] = i
-                d["type"] = str(node)
+                d["id"] = get_name(i)
+                d["type"] = get_name(node)
                 if children:
                     d["children"] = children
                 value = None


### PR DESCRIPTION
Fixes #18 
Add function ```get_name(obj)``` to recursively replace objects with their names except for ```lists```, `tuples`, `dicts`, `OrderedDicts`, and primitives.